### PR TITLE
Core - Fixing authentication bug

### DIFF
--- a/buildSrc/src/main/java/com/abhishek101/gamescout/Dependencies.kt
+++ b/buildSrc/src/main/java/com/abhishek101/gamescout/Dependencies.kt
@@ -15,7 +15,7 @@ fun generatedVersionName() =
     "${AppVersions.versionMajor}.${AppVersions.versionMinor}.${AppVersions.versionPatch}"
 
 object Libs {
-    const val androidGradlePlugin = "com.android.tools.build:gradle:7.0.0-beta03"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:7.0.0-beta05"
 
     const val timber = "com.jakewharton.timber:timber:4.7.1"
 

--- a/core/src/commonMain/kotlin/com/abhishek101/core/models/Authentication.kt
+++ b/core/src/commonMain/kotlin/com/abhishek101/core/models/Authentication.kt
@@ -1,10 +1,7 @@
 package com.abhishek101.core.models
 
-import com.abhishek101.core.db.Authentication
-import kotlinx.datetime.Clock
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.time.ExperimentalTime
 
 @Serializable
 data class AuthenticationRemoteEntity(
@@ -20,10 +17,3 @@ data class TwitchAuthenticationEntity(
 
 fun TwitchAuthenticationEntity.toAuthenticationRemoteEntity() =
     AuthenticationRemoteEntity(accessToken, expiresIn)
-
-@ExperimentalTime
-fun AuthenticationRemoteEntity.toAuthentication(clock: Clock = Clock.System): Authentication =
-    Authentication(
-        accessToken = this.accessToken,
-        expiresBy = clock.now().epochSeconds + this.expiresIn
-    )

--- a/core/src/commonMain/kotlin/com/abhishek101/core/repositories/AuthenticationRepository.kt
+++ b/core/src/commonMain/kotlin/com/abhishek101/core/repositories/AuthenticationRepository.kt
@@ -1,7 +1,6 @@
 package com.abhishek101.core.repositories
 
 import com.abhishek101.core.db.Authentication
-import com.abhishek101.core.models.toAuthentication
 import com.abhishek101.core.remote.AuthenticationApi
 import com.abhishek101.core.utils.DatabaseHelper
 import com.squareup.sqldelight.runtime.coroutines.asFlow
@@ -26,8 +25,8 @@ class AuthenticationRepositoryImpl(
     private val authenticationQueries = dbHelper.authenticationQueries
 
     override suspend fun authenticateUser() {
-        authenticationApi.authenticateUser().toAuthentication().apply {
-            authenticationQueries.setAuthenticationData(accessToken, expiresBy)
+        authenticationApi.authenticateUser().apply {
+            authenticationQueries.setAuthenticationData(accessToken, expiresIn)
         }
     }
 

--- a/core/src/commonMain/sqldelight/com/abhishek101/core/db/Authentication.sq
+++ b/core/src/commonMain/sqldelight/com/abhishek101/core/db/Authentication.sq
@@ -10,3 +10,6 @@ WHERE expiresBy > ?;
 setAuthenticationData:
 INSERT INTO Authentication(accessToken, expiresBy)
 VALUES (?,?);
+
+clearAuthentication:
+DELETE FROM Authentication;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Jul 08 23:03:34 PDT 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The AWS authetication lamba currently provides the expiration date
instead of the seconds to expiration. We were currently adding our
current time (thinking that we were getting seconds to expiration) so
that caused an issue where the expiration date on the database was set
to a riduculously high number and authentication failed to roll over to
the new token when we generated one.